### PR TITLE
Add missing QA scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:debug": "playwright test --debug",
     "playwright:install": "playwright install",
-    "playwright:install-deps": "playwright install-deps"
+    "playwright:install-deps": "playwright install-deps",
+    "test": "bun test",
+    "lint:sql": "bun scripts/lintSql.ts",
+    "check:migrations": "bun scripts/checkMigrations.ts"
   },
   "devDependencies": {
     "playwright": "^1.40.0",

--- a/scripts/lintSql.ts
+++ b/scripts/lintSql.ts
@@ -1,0 +1,37 @@
+import path from "path";
+import { readdir, readFile } from "fs/promises";
+
+async function lint() {
+  const backendDir = path.join(process.cwd(), "backend");
+  const services = await readdir(backendDir, { withFileTypes: true });
+  let hasError = false;
+
+  for (const service of services) {
+    if (!service.isDirectory()) continue;
+    const migrationsDir = path.join(backendDir, service.name, "migrations");
+    let files: string[];
+    try {
+      files = await readdir(migrationsDir);
+    } catch {
+      continue;
+    }
+
+    for (const file of files) {
+      if (!file.endsWith(".sql")) continue;
+      const filePath = path.join(migrationsDir, file);
+      const content = await readFile(filePath, "utf8");
+      const lines = content.trim().split(/\n/);
+      const last = lines[lines.length - 1];
+      if (!last.trim().endsWith(";")) {
+        console.error(`Missing semicolon in ${path.join(service.name, "migrations", file)}`);
+        hasError = true;
+      }
+    }
+  }
+
+  if (hasError) {
+    process.exit(1);
+  }
+}
+
+lint();


### PR DESCRIPTION
## Summary
- provide SQL linter script and expose it via `lint:sql`
- expose `check:migrations` and `test` scripts in package.json

## Testing
- `bun x biome check --apply .`
- `bun run lint:sql`
- `bun run check:migrations`
- `bun run test` *(fails: ENCORE_RUNTIME_LIB missing)*

------
https://chatgpt.com/codex/tasks/task_e_684da3a917548327b033ee0a217e137e