### PR TITLE
Fix route collision by removing unused habits service

### DIFF
--- a/backend/habits/encore.service.ts
+++ b/backend/habits/encore.service.ts
@@ -1,3 +1,0 @@
-import { Service } from "encore.dev/service";
-
-export default new Service("habits");


### PR DESCRIPTION
## Summary
- remove redundant `encore.service.ts` from `backend/habits`

This prevents duplicate routes from being registered during `encore run`.

## Testing
- `bun x @biomejs/biome check backend/habits/encore.service.ts` *(fails: file not found)*
- `bun x @biomejs/biome check .` *(fails: formatter differences)*
- `bun run test` *(fails: Playwright setup / vi.mock errors)*

------
https://chatgpt.com/codex/tasks/task_e_684da8701c348327a3984c9c99532f3d